### PR TITLE
461 - Add language tag on home page

### DIFF
--- a/src/components/molecules/LanguageChanger/LanguageChanger.tsx
+++ b/src/components/molecules/LanguageChanger/LanguageChanger.tsx
@@ -1,8 +1,19 @@
 import { FC } from 'react'
+import classNames from 'classnames'
+import classes from './classes.module.scss'
+import { useTranslation } from 'react-i18next'
 
 // TODO: implement once we have dropdown select component
 const LanguageChanger: FC = () => {
-  return <div>Keel:</div>
+  const { t } = useTranslation()
+  return (
+    <div className={classNames(classes.container)}>
+      <label>{t('header.language')}</label>
+      <span className={classNames(classes.fakeIconButton)}>
+        {t('language_option.estonian')}
+      </span>
+    </div>
+  )
 }
 
 export default LanguageChanger

--- a/src/components/molecules/LanguageChanger/classes.module.scss
+++ b/src/components/molecules/LanguageChanger/classes.module.scss
@@ -1,0 +1,17 @@
+@import 'styles/variables';
+@import 'styles/mixins';
+
+.container {
+  display: flex;
+  flex-direction: column;
+  position: relative;
+
+  label {
+    @include bodyTextSmallStyle;
+    font-weight: $font-weight-light;
+  }
+
+  span {
+    color: $color-primary;
+  }
+}

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -263,7 +263,11 @@
     "checked": "Valitud"
   },
   "header": {
-    "my_role": "Minu roll:"
+    "my_role": "Minu roll:",
+    "language": "Keel:"
+  },
+  "language_option": {
+    "estonian": "EST"
   },
   "roles": {
     "roles_management": "Rollihaldus",


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/461

To-do - display language in home page ("EST" with no arrow and dropdown, as estonian will be the only language for now)

How to test - Take a look at the header, see if it looks alright