### PR TITLE
501 - Adjust landing page buttons and redirection

### DIFF
--- a/src/components/organisms/LandingContent/LandingContent.tsx
+++ b/src/components/organisms/LandingContent/LandingContent.tsx
@@ -27,6 +27,7 @@ const LandingContent: FC<LandingContentProps> = ({ className }) => {
             children={t('button.check_tutorial')}
             href={isUserLoggedIn ? '/manual' : undefined}
             className={classes.bigButton}
+            hidden={!isUserLoggedIn}
           />
           <Button
             appearance={AppearanceTypes.Primary}

--- a/src/components/organisms/LandingContent/LandingContent.tsx
+++ b/src/components/organisms/LandingContent/LandingContent.tsx
@@ -25,6 +25,7 @@ const LandingContent: FC<LandingContentProps> = ({ className }) => {
           <Button
             appearance={AppearanceTypes.Secondary}
             children={t('button.check_tutorial')}
+            href={isUserLoggedIn ? '/manual' : undefined}
             className={classes.bigButton}
           />
           <Button

--- a/src/components/organisms/LandingContent/classes.module.scss
+++ b/src/components/organisms/LandingContent/classes.module.scss
@@ -46,7 +46,7 @@
     .buttonsContainer {
       margin-top: spacing(4);
       display: grid;
-      grid-template-columns: auto 96px;
+      grid-template-columns: auto auto;
       grid-gap: spacing(2);
 
       @media (max-width: $medium_mobile) {


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/501

To-do: 
- Make "Lisa uus tellimus" button text not be on multiple lines
- Make clicking on "Vaata kasutusjuhendit" button direct the user to the user manual page
- Remove "Vaata kasutusjuhendit" button from the unauthorized landing page, there should only be "Sisene" button

How to test - Check both of the landing pages (logged in and not logged in), click on the buttons to verify their intended behaviour