### PR TITLE
Fix-504 Rollihaldus improvements and fixes

### DIFF
--- a/src/components/molecules/Tab/Tab.tsx
+++ b/src/components/molecules/Tab/Tab.tsx
@@ -78,12 +78,12 @@ const Tab: FC<TabType> = ({
   }, [])
 
   useEffect(() => {
-    if (!isEditMode && tempName !== name && id && onChangeName) {
+    if (tempName !== name && id && onChangeName) {
       onChangeName(id, tempName)
     }
-    // We only want to run this, when isEditMode changes
+    // We  want to run this, when tempName changes
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [isEditMode])
+  }, [tempName])
 
   useEffect(() => {
     if (name !== tempName) {
@@ -94,8 +94,10 @@ const Tab: FC<TabType> = ({
   }, [name])
 
   const isEditModeActive = isActive && isEditMode
+  const isTemporaryRole = startsWith(id, 'temp')
+
   const handleEnterEditMode = useCallback(() => {
-    if (!isEditMode && !editDisabled) {
+    if ((!isEditMode && !editDisabled) || (!isEditMode && isTemporaryRole)) {
       setIsEditMode(!isEditMode)
     }
   }, [isEditMode, editDisabled])

--- a/src/i18n/locales/et.json
+++ b/src/i18n/locales/et.json
@@ -154,7 +154,7 @@
     "save_changes": "Salvesta muudatused",
     "delete_this_role": "Kustuta see roll",
     "add_new_order": "Lisa uus tellimus",
-    "add_new_role": "lisa uus roll",
+    "add_new_role": "Lisa uus roll",
     "deactivate_account": "Deaktiveeri konto",
     "archive_account": "Arhiveeri konto",
     "activate_account": "Aktiveeri konto",


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/504 (issues 1 and 3)

To-do:
Issue 1 - Allow user with add_role and view_role privileges to add/modify role name after clicking away from the input field (whether selecting check-boxes or just clicking elsewhere on the screen) 

Issue 3 - Make the "Tühista" and "Salvesta muudatused" buttons active immediately after changing the role name (without pressing enter or adding privileges)

How to test:
Issue 1 - Log in with a user that only has add_role and view_role privileges. Click on "Lisa uus roll", first add privileges and then add a name, try to also modify the name and create the role. You can also try the same with a user that has role edit rights as well, just to make sure the flow works there as well.

Issue 3 - With whichever user, modify an existing role name and without pressing space/enter or changing privileges, see if the form buttons are active (the ticket issue 3 has a video you can look at for better understanding)