### PR TITLE
Fix-553 - Order table filter and dropdown changes

### DIFF
--- a/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
+++ b/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
@@ -92,7 +92,7 @@ const OrdersTable: FC = () => {
             ext_id,
             reference_number,
             deadline_at,
-            type: type_classifier_value?.value || '',
+            type: type_classifier_value?.name || '',
             status,
             tags: map(tags, (value) => value?.name || ''),
             price,

--- a/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
+++ b/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
@@ -125,23 +125,26 @@ const OrdersTable: FC = () => {
 
   const handleModifiedFilterChange = useCallback(
     (filters?: FilterFunctionType) => {
-      const { language_directions, ...rest } = filters || {}
-      const typedLanguageDirection = language_directions as string[]
+      let currentFilters = filters
+      if (filters && 'language_directions' in filters) {
+        const { language_directions, ...rest } = filters || {}
+        const typedLanguageDirection = language_directions as string[]
 
-      const new_value = map(
-        typedLanguageDirection,
-        (languageDirectionString) => {
-          return languageDirectionString.replace('_', ':')
+        const modifiedLanguageDirections = map(
+          typedLanguageDirection,
+          (languageDirectionString) => {
+            return languageDirectionString.replace('_', ':')
+          }
+        )
+
+        currentFilters = {
+          language_directions: modifiedLanguageDirections,
+          ...rest,
         }
-      )
-
-      const newFilters = {
-        language_directions: new_value,
-        ...rest,
       }
 
       if (handleFilterChange) {
-        handleFilterChange(newFilters)
+        handleFilterChange(currentFilters)
       }
     },
     [handleFilterChange]

--- a/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
+++ b/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
@@ -28,6 +28,7 @@ import { Privileges } from 'types/privileges'
 import useAuth from 'hooks/useAuth'
 import { useFetchTags } from 'hooks/requests/useTags'
 import { TagTypes } from 'types/tags'
+import { useLanguageDirections } from 'hooks/requests/useLanguageDirections'
 
 // TODO: statuses might come from BE instead
 // Currently unclear
@@ -67,6 +68,8 @@ const OrdersTable: FC = () => {
   const { tagsFilters = [] } = useFetchTags({
     type: TagTypes.Order,
   })
+  const { languageDirectionFilters, loadMore, handleSearch } =
+    useLanguageDirections({})
 
   const statusFilters = map(OrderStatus, (status) => ({
     label: t(`orders.status.${status}`),
@@ -176,7 +179,10 @@ const OrdersTable: FC = () => {
         )
       },
       meta: {
-        filterOption: { tags: tagsFilters },
+        filterOption: { language_directions: languageDirectionFilters },
+        onEndReached: loadMore,
+        onSearch: handleSearch,
+        showSearch: true,
       },
     }),
     columnHelper.accessor('type', {
@@ -194,6 +200,10 @@ const OrdersTable: FC = () => {
             ))}
           </div>
         )
+      },
+      meta: {
+        filterOption: { tags_ids: tagsFilters },
+        showSearch: true,
       },
     }),
     columnHelper.accessor('status', {

--- a/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
+++ b/src/components/organisms/tables/OrdersTable/OrdersTable.tsx
@@ -29,6 +29,7 @@ import useAuth from 'hooks/useAuth'
 import { useFetchTags } from 'hooks/requests/useTags'
 import { TagTypes } from 'types/tags'
 import { useLanguageDirections } from 'hooks/requests/useLanguageDirections'
+import { FilterFunctionType } from 'types/collective'
 
 // TODO: statuses might come from BE instead
 // Currently unclear
@@ -122,6 +123,30 @@ const OrdersTable: FC = () => {
     },
   })
 
+  const handleModifiedFilterChange = useCallback(
+    (filters?: FilterFunctionType) => {
+      const { language_directions, ...rest } = filters || {}
+      const typedLanguageDirection = language_directions as string[]
+
+      const new_value = map(
+        typedLanguageDirection,
+        (languageDirectionString) => {
+          return languageDirectionString.replace('_', ':')
+        }
+      )
+
+      const newFilters = {
+        language_directions: new_value,
+        ...rest,
+      }
+
+      if (handleFilterChange) {
+        handleFilterChange(newFilters)
+      }
+    },
+    [handleFilterChange]
+  )
+
   const onSubmit: SubmitHandler<FormValues> = useCallback(
     (payload) => {
       handleFilterChange({
@@ -202,7 +227,7 @@ const OrdersTable: FC = () => {
         )
       },
       meta: {
-        filterOption: { tags_ids: tagsFilters },
+        filterOption: { tag_ids: tagsFilters },
         showSearch: true,
       },
     }),
@@ -263,7 +288,7 @@ const OrdersTable: FC = () => {
         tableSize={TableSizeTypes.M}
         paginationData={paginationData}
         onPaginationChange={handlePaginationChange}
-        onFiltersChange={handleFilterChange}
+        onFiltersChange={handleModifiedFilterChange}
         onSortingChange={handleSortingChange}
         headComponent={
           <div className={classes.topSection}>

--- a/src/components/organisms/tables/SubOrdersTable/SubOrdersTable.tsx
+++ b/src/components/organisms/tables/SubOrdersTable/SubOrdersTable.tsx
@@ -85,7 +85,7 @@ const SubOrdersTable: FC = () => {
             ext_id,
             reference_number: project?.reference_number,
             deadline_at,
-            type: project?.type_classifier_value?.value || '',
+            type: project?.type_classifier_value?.name || '',
             status,
             price,
             language_directions: [

--- a/src/components/organisms/tables/VendorsTable/VendorsTable.tsx
+++ b/src/components/organisms/tables/VendorsTable/VendorsTable.tsx
@@ -99,24 +99,27 @@ const VendorsTable: FC<VendorsTableProps> = ({
   const handleModifiedFilterChange = useCallback(
     (filters?: FilterFunctionType) => {
       // language_direction will be an array of strings
-      const { language_direction, ...rest } = filters || {}
-      const typedLanguageDirection = language_direction as string[]
+      let currentFilters = filters
+      if (filters && 'language_direction' in filters) {
+        const { language_direction, ...rest } = filters || {}
+        const typedLanguageDirection = language_direction as string[]
 
-      const langPair = map(
-        typedLanguageDirection,
-        (languageDirectionString) => {
-          const [src, dst] = split(languageDirectionString, '_')
-          return { src, dst }
+        const langPair = map(
+          typedLanguageDirection,
+          (languageDirectionString) => {
+            const [src, dst] = split(languageDirectionString, '_')
+            return { src, dst }
+          }
+        )
+
+        currentFilters = {
+          lang_pair: langPair,
+          ...rest,
         }
-      )
-
-      const newFilters = {
-        lang_pair: langPair,
-        ...rest,
       }
 
       if (handleFilterChange) {
-        handleFilterChange(newFilters)
+        handleFilterChange(currentFilters)
       }
     },
     [handleFilterChange]


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/553

To-do: 
- Add missing project type translations to the table
- Add the right drop-down and filtering to "Keelesuunad" and "Tellimuse sildid"
- Fix "Keelesuunad" filter resetting when an additional filter is picked after it. Issue appears in "Tellimused" and "Teostajate andmebaas" tables.

How to test - 
Go to the "Tellimused" view and look if the types are translated and try to filter by "Tellimuse sildid" and "Keelesuunad", try using both filters at the same time as well. 
Also check out "Teostajate andmebaas" table filters, because this table also had the third todo issue.