### PR TITLE
FIX-478 - Use correct translation during deletion of deactivation date

### DIFF
--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -271,7 +271,7 @@ const UserPage: FC = () => {
 
   const handleOnRemoveDeactivationDate = () => {
     showModal(ModalTypes.UserAndRoleManagement, {
-      title: t('modal.edit_deactivation_date'),
+      title: t('modal.remove_deactivation_date'),
       modalContent: t('modal.deactivation_date_content', {
         date: formattedDeactivationDate,
       }),


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/478

To-do - Use the correct translation when deleting deactivation date

How to test - Deactivate a user and then go to remove the deactivation date to check if the correct translation is used