### PR TITLE
FIX-486 - Modify hidden clause for deactivation date delete button

### DIFF
--- a/src/pages/UserPage/UserPage.tsx
+++ b/src/pages/UserPage/UserPage.tsx
@@ -348,7 +348,9 @@ const UserPage: FC = () => {
           icon={Delete}
           className={classes.button}
           onClick={handleOnRemoveDeactivationDate}
-          hidden={isActivationButtonHidden}
+          hidden={
+            !isDeactivationDateInTheFuture || status === UserStatus.Archived
+          }
         />
       </div>
 


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/486

To-do - Remove delete deactivation date button for users that are already deactivated. It should be visible only to users who will be deactivated in the future.

How to test - Find a deactivated user that is past the deactivation date. At the time of writing - Gabriella Deakt for example. Check if the delete button is there. Can also check users who are archived or will soon be deactivated.