### PR TITLE
FIX-511 - Add pagination index reset logic during filtering

### DIFF
--- a/src/components/organisms/DataTable/DataTable.tsx
+++ b/src/components/organisms/DataTable/DataTable.tsx
@@ -116,6 +116,10 @@ const DataTable = <TData,>(
     pageSize: hidePagination ? 10000 : per_page || 10,
   })
 
+  if (last_page && last_page < pagination.pageIndex) {
+    setPagination({ pageIndex: 0, pageSize: per_page || 10 })
+  }
+
   if (last_page === pagination.pageIndex) {
     setPagination({ pageIndex: last_page - 1, pageSize: per_page || 10 })
   }


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/511

To-do - If user is on page 3 or further and the search result happens to have less pages then the current page, the user cannot see the search results without clicking on the navigation. This happens on all tables.

How to test - For example go to "Alam-tellimused" and click on pagination bigger than 2 and type `10--5` into the search, the pagination should now reset to page one so you can see the one result. Can also test all the other tables for the same.

