### PR TITLE
FIX-582 - Add better queryKey and keepPreviousData to tm subprojects fetch

### DIFF
--- a/src/hooks/requests/useTranslationMemories.ts
+++ b/src/hooks/requests/useTranslationMemories.ts
@@ -232,9 +232,10 @@ export const useFetchTranslationMemorySubProjects = ({
   const { isLoading, isError, isFetching, data } =
     useQuery<SubProjectsResponse>({
       enabled: !!id,
-      queryKey: ['tm-subProjects', id],
+      queryKey: ['tm-subProjects', id, filters],
       queryFn: () =>
         apiClient.get(`${endpoints.TM_SUB_PROJECTS}/${id}`, filters),
+      keepPreviousData: true,
     })
 
   const { meta: paginationData, data: subProjects } = data || {}


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/582

To-do - TM related sub-projects tables does not update when paginating or choosing how many rows to display

How to test - Go to Tõlkemälud, choose marius memory for example and check that the table of related sub projects reflects the pagination and row amount change properly