### PR TITLE
NEW-615 Add filtering by type for Projects and SubProjects tables

### DIFF
--- a/src/components/organisms/tables/ProjectsTable/ProjectsTable.tsx
+++ b/src/components/organisms/tables/ProjectsTable/ProjectsTable.tsx
@@ -81,6 +81,7 @@ const ProjectsTable: FC = () => {
     only_show_personal_projects: onlyPersonalProjectsAllowed
       ? 1
       : Number(searchParams.get('only_show_personal_projects')) || 0,
+    type_classifier_value_ids: searchParams.getAll('type_classifier_value_ids'),
   }
 
   const {

--- a/src/components/organisms/tables/ProjectsTable/ProjectsTable.tsx
+++ b/src/components/organisms/tables/ProjectsTable/ProjectsTable.tsx
@@ -30,6 +30,8 @@ import { useFetchTags } from 'hooks/requests/useTags'
 import { TagTypes } from 'types/tags'
 import { useLanguageDirections } from 'hooks/requests/useLanguageDirections'
 import { FilterFunctionType } from 'types/collective'
+import { useClassifierValuesFetch } from 'hooks/requests/useClassifierValues'
+import { ClassifierValueType } from 'types/classifierValues'
 
 // TODO: statuses might come from BE instead
 // Currently unclear
@@ -79,6 +81,9 @@ const ProjectsTable: FC = () => {
   })
   const { tagsFilters = [] } = useFetchTags({
     type: TagTypes.Project,
+  })
+  const { classifierValuesFilters: typeFilters } = useClassifierValuesFetch({
+    type: ClassifierValueType.ProjectType,
   })
   const {
     languageDirectionFilters,
@@ -150,7 +155,7 @@ const ProjectsTable: FC = () => {
     (filters?: FilterFunctionType) => {
       let currentFilters = filters
       if (filters && 'language_directions' in filters) {
-        const { language_directions, ...rest } = filters || {}
+        const { language_directions, ...rest } = currentFilters || {}
         const typedLanguageDirection = language_directions as string[]
 
         const modifiedLanguageDirections = map(
@@ -162,6 +167,16 @@ const ProjectsTable: FC = () => {
 
         currentFilters = {
           language_directions: modifiedLanguageDirections,
+          ...rest,
+        }
+      }
+
+      if (filters && 'type_classifier_value_ids' in filters) {
+        const { type_classifier_value_ids, ...rest } = currentFilters || {}
+        const typedTypeClassifierValueId = type_classifier_value_ids as string
+
+        currentFilters = {
+          type_classifier_value_ids: [typedTypeClassifierValueId],
           ...rest,
         }
       }
@@ -239,6 +254,11 @@ const ProjectsTable: FC = () => {
     columnHelper.accessor('type', {
       header: () => t('label.type'),
       footer: (info) => info.column.id,
+      meta: {
+        filterOption: { type_classifier_value_ids: typeFilters },
+        filterValue: filters.type_classifier_value_ids,
+        isCustomSingleDropdown: true,
+      },
     }),
     columnHelper.accessor('tags', {
       header: () => t('label.project_tags'),

--- a/src/components/organisms/tables/SubProjectsTable/SubProjectsTable.tsx
+++ b/src/components/organisms/tables/SubProjectsTable/SubProjectsTable.tsx
@@ -28,6 +28,8 @@ import { Privileges } from 'types/privileges'
 import useAuth from 'hooks/useAuth'
 import { useLanguageDirections } from 'hooks/requests/useLanguageDirections'
 import { FilterFunctionType } from 'types/collective'
+import { useClassifierValuesFetch } from 'hooks/requests/useClassifierValues'
+import { ClassifierValueType } from 'types/classifierValues'
 
 type SubProjectTableRow = {
   ext_id: string
@@ -86,6 +88,9 @@ const SubProjectsTable: FC = () => {
     label: t(`projects.status.${status}`),
     value: status,
   }))
+  const { classifierValuesFilters: typeFilters } = useClassifierValuesFetch({
+    type: ClassifierValueType.ProjectType,
+  })
 
   const projectRows = useMemo(
     () =>
@@ -130,7 +135,7 @@ const SubProjectsTable: FC = () => {
     (filters?: FilterFunctionType) => {
       let currentFilters = filters
       if (filters && 'language_direction' in filters) {
-        const { language_direction, ...rest } = filters || {}
+        const { language_direction, ...rest } = currentFilters || {}
         const typedLanguageDirection = language_direction as string[]
 
         const modifiedLanguageDirections = map(
@@ -142,6 +147,16 @@ const SubProjectsTable: FC = () => {
 
         currentFilters = {
           language_direction: modifiedLanguageDirections,
+          ...rest,
+        }
+      }
+
+      if (filters && 'type_classifier_value_id' in filters) {
+        const { type_classifier_value_id, ...rest } = currentFilters || {}
+        const typedTypeClassifierValueId = type_classifier_value_id as string
+
+        currentFilters = {
+          type_classifier_value_id: [typedTypeClassifierValueId],
           ...rest,
         }
       }
@@ -220,6 +235,11 @@ const SubProjectsTable: FC = () => {
     columnHelper.accessor('type', {
       header: () => t('label.type'),
       footer: (info) => info.column.id,
+      meta: {
+        filterOption: { type_classifier_value_id: typeFilters },
+        filterValue: filters.type_classifier_value_id,
+        isCustomSingleDropdown: true,
+      },
     }),
     columnHelper.accessor('status', {
       header: () => t('label.status'),

--- a/src/components/organisms/tables/SubProjectsTable/SubProjectsTable.tsx
+++ b/src/components/organisms/tables/SubProjectsTable/SubProjectsTable.tsx
@@ -72,6 +72,7 @@ const SubProjectsTable: FC = () => {
     only_show_personal_projects: Number(
       searchParams.get('only_show_personal_projects') || 0
     ),
+    type_classifier_value_id: searchParams.getAll('type_classifier_value_id'),
   }
 
   const {

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -231,7 +231,7 @@ export type ProjectsPayloadType = PaginationFunctionType &
     language_directions?: string[]
     statuses?: string[]
     tag_ids?: string[]
-    type_classifier_value_ids?: string
+    type_classifier_value_ids?: string | string[]
   }
 
 export type SubProjectsPayloadType = PaginationFunctionType &
@@ -240,7 +240,7 @@ export type SubProjectsPayloadType = PaginationFunctionType &
     only_show_personal_projects?: number
     status?: string[]
     language_direction?: string[]
-    type_classifier_value_id?: string
+    type_classifier_value_id?: string | string[]
   }
 
 export interface ProjectsResponse {

--- a/src/types/projects.ts
+++ b/src/types/projects.ts
@@ -230,6 +230,7 @@ export type ProjectsPayloadType = PaginationFunctionType &
     only_show_personal_projects?: number
     language_directions?: string[]
     statuses?: string[]
+    type_classifier_value_ids?: string
   }
 
 export type SubProjectsPayloadType = PaginationFunctionType &
@@ -238,6 +239,7 @@ export type SubProjectsPayloadType = PaginationFunctionType &
     only_show_personal_projects?: number
     statuses?: string[]
     language_direction?: string[]
+    type_classifier_value_id?: string
   }
 
 export interface ProjectsResponse {


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/615

To-do - Add filtering by project type in project and sub-project list view

How to test - Check out Projects and Sub-projects tables and try out the new project type filter