### PR TITLE
FIX-405 Status filter modal goes out of the table in Kasutajate haldus

### DIFF
--- a/src/components/organisms/tables/AddedUsersTable/AddedUsersTable.tsx
+++ b/src/components/organisms/tables/AddedUsersTable/AddedUsersTable.tsx
@@ -126,10 +126,12 @@ const AddedUsersTable: FC<AddedUsersProps> = ({ hidden }) => {
         </div>
       ),
       footer: (info) => info.column.id,
+      size: 500,
     }),
     columnHelper.accessor('name', {
       header: () => t('label.name'),
       footer: (info) => info.column.id,
+      size: 200,
       meta: {
         sortingOption: ['asc', 'desc'],
         currentSorting: filters?.sort_by === 'name' ? filters.sort_order : '',
@@ -138,6 +140,7 @@ const AddedUsersTable: FC<AddedUsersProps> = ({ hidden }) => {
     columnHelper.accessor('department', {
       header: () => t('label.department'),
       footer: (info) => info.column.id,
+      size: 200,
       meta: {
         filterOption: { departments: departmentFilters },
         filterValue: filters?.departments || [],
@@ -149,6 +152,7 @@ const AddedUsersTable: FC<AddedUsersProps> = ({ hidden }) => {
         return join(info.renderValue(), ', ')
       },
       footer: (info) => info.column.id,
+      size: 200,
       meta: {
         filterOption: { roles: rolesFilters },
         filterValue: filters?.roles || [],
@@ -160,6 +164,7 @@ const AddedUsersTable: FC<AddedUsersProps> = ({ hidden }) => {
       cell: ({ getValue }) => {
         return t(`user.status.${getValue()}`)
       },
+      size: 100,
       meta: {
         filterOption: {
           statuses: [


### PR DESCRIPTION
Ticket - https://github.com/keeleinstituut/tv-tolkevarav/issues/405

To-do - Status filter modal goes out of the table in Kasutajate haldus

How to test - This issue seems to occur on browser windows that are wider than 1600px, so use a nice big monitor or simulate the screen size when you open the Status filter in the Kasutajate Haldus

I assigned the size values by eye, if they should be different or somehow calculated then let me know :)