### PR TITLE
554 - Validating site accessibility (FE)

### DIFF
--- a/src/components/atoms/Container/Container.tsx
+++ b/src/components/atoms/Container/Container.tsx
@@ -11,7 +11,11 @@ const Container = (
   ref: Ref<HTMLDivElement>
 ) => {
   return (
-    <section ref={ref} className={classNames(classes.container, className)}>
+    <section
+      ref={ref}
+      className={classNames(classes.container, className)}
+      tabIndex={0}
+    >
       {children}
     </section>
   )

--- a/src/components/molecules/TimeColumn/TimeColumn.tsx
+++ b/src/components/molecules/TimeColumn/TimeColumn.tsx
@@ -13,7 +13,6 @@ export type TimeColumnProps = {
   value: number
   isTimeColumnOpen?: boolean
   isHourValue?: boolean
-  autoFocus?: boolean
 }
 
 const TimeColumn = ({
@@ -22,7 +21,6 @@ const TimeColumn = ({
   setValue,
   value,
   isTimeColumnOpen,
-  autoFocus,
 }: TimeColumnProps) => {
   const { t } = useTranslation()
   const controlTop = () => {
@@ -60,7 +58,6 @@ const TimeColumn = ({
           isTimeColumnOpen && classes.focusTimeColumnButton
         )}
         aria-label={t('button.increase')}
-        // autoFocus={isTimeColumnOpen && isHourValue}
       >
         <ButtonArrow />
       </BaseButton>
@@ -72,7 +69,6 @@ const TimeColumn = ({
         onChange={handleInputChange}
         min={start}
         max={end}
-        autoFocus={autoFocus}
       />
       <BaseButton
         onClick={controlBottom}

--- a/src/components/molecules/TimeDropdown/TimeDropdown.tsx
+++ b/src/components/molecules/TimeDropdown/TimeDropdown.tsx
@@ -6,6 +6,7 @@ import useModalContext from 'hooks/useModalContext'
 import { createPortal } from 'react-dom'
 import useElementPosition from 'hooks/useElementPosition'
 import useTableContext from 'hooks/useTableContext'
+import FocusTrap from 'focus-trap-react'
 
 import classes from './classes.module.scss'
 
@@ -105,52 +106,55 @@ const TimeDropdownComponent = forwardRef<HTMLDivElement, TimeDropdownProps>(
       }
     }
 
+    if (!isTimeColumnOpen || disabled) return null
+
     return (
-      <div
-        className={
-          !isTimeColumnOpen || disabled
-            ? classes.hiddenContainer
-            : classes.timeColumnContainer
-        }
-        ref={ref}
-        style={{
-          zIndex: 51 + (errorZIndex || 0),
-          ...(wrapperRef
-            ? {
-                left: useLeftPosition ? 'unset' : left - 2,
-                right: useLeftPosition ? right - left : 'unset',
-                top: top + 40,
-              }
-            : {}),
+      <FocusTrap
+        focusTrapOptions={{
+          clickOutsideDeactivates: true,
         }}
-        onKeyDown={handleKeyDown}
       >
-        <TimeColumn
-          start={0}
-          end={24}
-          value={hourValue}
-          setValue={handleSetHour}
-          isTimeColumnOpen={isTimeColumnOpen}
-          isHourValue
-          autoFocus={isTimeColumnOpen}
-        />
-        <TimeColumn
-          start={0}
-          end={60}
-          value={minuteValue}
-          setValue={handleSetMinute}
-          isTimeColumnOpen={isTimeColumnOpen}
-        />
-        {showSeconds && (
+        <div
+          className={classes.timeColumnContainer}
+          ref={ref}
+          style={{
+            zIndex: 51 + (errorZIndex || 0),
+            ...(wrapperRef
+              ? {
+                  left: useLeftPosition ? 'unset' : left - 2,
+                  right: useLeftPosition ? right - left : 'unset',
+                  top: top + 40,
+                }
+              : {}),
+          }}
+          onKeyDown={handleKeyDown}
+        >
+          <TimeColumn
+            start={0}
+            end={24}
+            value={hourValue}
+            setValue={handleSetHour}
+            isTimeColumnOpen={isTimeColumnOpen}
+            isHourValue
+          />
           <TimeColumn
             start={0}
             end={60}
-            value={secondValue}
-            setValue={handleSetSecond}
+            value={minuteValue}
+            setValue={handleSetMinute}
             isTimeColumnOpen={isTimeColumnOpen}
           />
-        )}
-      </div>
+          {showSeconds && (
+            <TimeColumn
+              start={0}
+              end={60}
+              value={secondValue}
+              setValue={handleSetSecond}
+              isTimeColumnOpen={isTimeColumnOpen}
+            />
+          )}
+        </div>
+      </FocusTrap>
     )
   }
 )

--- a/src/components/molecules/TimeDropdown/classes.module.scss
+++ b/src/components/molecules/TimeDropdown/classes.module.scss
@@ -1,9 +1,5 @@
 @import 'styles/variables';
 
-.hiddenContainer {
-  display: none;
-}
-
 .timeColumnContainer {
   display: flex;
   border: 1px solid $color-input-border;

--- a/src/components/molecules/TimePickerInput/TimePickerInput.tsx
+++ b/src/components/molecules/TimePickerInput/TimePickerInput.tsx
@@ -125,6 +125,7 @@ const TimePickerInput = forwardRef<HTMLInputElement, TimePickerInputProps>(
     const handleKeyDown = (event: React.KeyboardEvent<HTMLDivElement>) => {
       if (event.key === 'Enter') {
         setTimeColumnOpen(!isTimeColumnOpen)
+        event.preventDefault()
       }
       if (event.key === 'Tab' && isTimeColumnOpen) {
         event.preventDefault()

--- a/src/components/organisms/DataTable/DataTable.tsx
+++ b/src/components/organisms/DataTable/DataTable.tsx
@@ -63,6 +63,7 @@ type DataTableProps<TData extends RowData> = {
   hidden?: boolean
   getSubRows?: (originalRow: TData, index: number) => TData[] | undefined
   hidePagination?: boolean
+  isHorizontallyScrollable?: boolean
   hidePaginationSelectionInput?: boolean
   getRowStyles?: (row: {
     parentId?: string
@@ -98,6 +99,7 @@ const DataTable = <TData,>(
     getSubRows,
     pageSizeOptions,
     hidePagination = false,
+    isHorizontallyScrollable = false,
     headComponent,
     className,
     hidePaginationSelectionInput = false,
@@ -174,13 +176,24 @@ const DataTable = <TData,>(
         tableRef: ref,
       }}
     >
-      <Container ref={ref} className={className}>
+      <Container
+        ref={ref}
+        className={classNames(
+          isHorizontallyScrollable ? classes.tableWrapper : '',
+          className
+        )}
+      >
         <h4 className={classes.title} hidden={!title}>
           {title}
         </h4>
         {headComponent}
         <div
-          className={classNames(classes.tableWrapper, tableWrapperClassName)}
+          className={classNames(
+            isHorizontallyScrollable
+              ? classes.horizontallyScrollableClassName
+              : classes.tableWrapper,
+            tableWrapperClassName
+          )}
           id={horizontalWrapperId}
         >
           <table className={classNames(classes.dataTable, classes[tableSize])}>

--- a/src/components/organisms/DataTable/classes.module.scss
+++ b/src/components/organisms/DataTable/classes.module.scss
@@ -5,8 +5,16 @@
   margin: spacing(6) spacing(4);
 }
 
+.horizontallyScrollableClassName {
+  overflow-x: unset;
+}
+
 .tableWrapper {
   overflow-x: auto;
+}
+
+.tableWrapper,
+.horizontallyScrollableClassName {
   white-space: nowrap;
 
   .dataTable {

--- a/src/components/organisms/SelectionControlsInput/SelectionControlsInput.tsx
+++ b/src/components/organisms/SelectionControlsInput/SelectionControlsInput.tsx
@@ -198,6 +198,7 @@ const SelectionControlsInput = forwardRef<
         disabled={disabled}
         onClick={toggleDropdown}
         tabIndex={0}
+        autoFocus={true}
       >
         <p
           hidden={!placeholder && multiple}

--- a/src/components/organisms/modals/CatAnalysisModal/CatAnalysisModal.tsx
+++ b/src/components/organisms/modals/CatAnalysisModal/CatAnalysisModal.tsx
@@ -173,6 +173,7 @@ const CatAnalysisModal: FC<CatAnalysisModalProps> = ({
           columns={tableColumns}
           tableSize={TableSizeTypes.M}
           hidePagination
+          isHorizontallyScrollable
           headComponent={
             <div className={classes.titleRow}>
               <h3>

--- a/src/components/organisms/tables/SelectVendorsTable/SelectVendorsTable.tsx
+++ b/src/components/organisms/tables/SelectVendorsTable/SelectVendorsTable.tsx
@@ -378,6 +378,7 @@ const SelectVendorsTable = <TFormValues extends FieldValues>({
         onFiltersChange={handleModifiedFilterChange}
         onSortingChange={handleSortingChange}
         className={classes.tableContainer}
+        isHorizontallyScrollable
       />
     </Root>
   )


### PR DESCRIPTION
Fixed issues:
1. Cat project - Vaata cat arvestust - Can't scroll table left/right
2. Create new order - Abifailid - Select file type from dropdown menu - focus goes back to top left corner. Is it possible that focus stays on dropdown menu?
3. Asutuse sätted - edit worktimes - can't edit times with arrow buttons, focus doesn't go to arrow button -> it's hard to understand how it works.
- If I open edit worktime modal and move focus to time field and click enter, it opens time editing buttons. Now it's unclear how to set the time and close time editing buttons. I can close it with esc button, but when I move focus to another time field and click enter, modal closes and worktimes are saved.
- If I edit end time first and then move focus to start time and click enter, modal closes and worktimes are saved
- If I firstly delete any row and then move focus to any time field and click enter, modal closes and worktimes are saved.