### PR TITLE
Remove unused cookie from tv-web/auth-server #920

### DIFF
--- a/auth-server/src/routes/middleware.js
+++ b/auth-server/src/routes/middleware.js
@@ -44,20 +44,6 @@ const autoRefreshAccessToken = () => async (req, res, next) => {
     }
   }
 
-  if (!!accessToken) {
-    const { exp } = jwtDecode(req.oidc.refreshToken) // Reread refresh token from session in case it was updated
-
-    const isSecure = req.secure || req.protocol === 'https'
-    
-    res.cookie('session-expires', exp, {
-      sameSite: 'lax',
-      secure: isSecure,
-      httpOnly: false,
-    })
-  } else {
-    res.clearCookie('session-expires')
-  }
-
   next()
 }
 

--- a/auth-server/src/routes/middleware.js
+++ b/auth-server/src/routes/middleware.js
@@ -46,7 +46,14 @@ const autoRefreshAccessToken = () => async (req, res, next) => {
 
   if (!!accessToken) {
     const { exp } = jwtDecode(req.oidc.refreshToken) // Reread refresh token from session in case it was updated
-    res.cookie('session-expires', exp)
+
+    const isSecure = req.secure || req.protocol === 'https'
+    
+    res.cookie('session-expires', exp, {
+      sameSite: 'lax',
+      secure: isSecure,
+      httpOnly: false,
+    })
   } else {
     res.clearCookie('session-expires')
   }

--- a/src/components/contexts/AuthContext.tsx
+++ b/src/components/contexts/AuthContext.tsx
@@ -7,7 +7,6 @@ import { InstitutionSelectModalProps } from 'components/organisms/modals/Institu
 import { ModalTypes, showModal } from 'components/organisms/modals/ModalRoot'
 import useAsRef from 'hooks/useAsRef'
 import i18n from 'i18n/i18n'
-import Cookies from 'js-cookie'
 import { isEmpty, size, includes } from 'lodash'
 import {
   FC,
@@ -110,6 +109,7 @@ export const AuthProvider: FC<PropsWithChildren> = (props) => {
       onSuccess(data) {
         setCsrfToken(data.csrfToken)
       },
+      refetchInterval: 60000, // Refetch every 60 seconds
     }
   )
 
@@ -209,9 +209,9 @@ export const AuthProvider: FC<PropsWithChildren> = (props) => {
 
   const checkSession = useCallback(() => {
     const now = Math.ceil(Date.now() / 1000)
-    const sessionExpires = Number(Cookies.get('session-expires'))
+    const sessionExpires = context?.sessionExpiry
 
-    if (!sessionExpires) {
+    if (!sessionExpires || !context?.authenticated) {
       return
     }
     const remaining = sessionExpires - now
@@ -246,7 +246,7 @@ export const AuthProvider: FC<PropsWithChildren> = (props) => {
     if (isSessionExpired) {
       logout()
     }
-  }, [logout])
+  }, [logout, context])
 
   const checkSessionRef = useAsRef(checkSession)
 


### PR DESCRIPTION
Task: https://github.com/keeleinstituut/tv-tolkevarav/issues/920


Add "SameSite" and "Secure" configuration for the `session-expires` cookie.

The cookie wasn't removed due to the logic on the frontend application that relies on it.

Frontend polls  the `session-expires` cookie every 1 second and do the following:
  - Calculate remaining session time.
  - Show warnings at thresholds.
  - Auto-logout if expired.